### PR TITLE
Bump to 0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.vscode
+/vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "barcodes"
-authors = ["Blossomi Shymae"]
-description = "Print your pride in the terminal!"
+authors = ["Blossomi Shymae","kkCoder111"]
+description = "Print your pride in the terminal! There are many flags to choose from."
 repository = "https://github.com/BlossomiShymae/barcodes"
 license = "GPL-3.0-only"
 
 keywords = ["terminal", "cli", "pride", "lgbt"]
 categories = ["command-line-utilities"]
 
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,7 +158,7 @@ impl Flags {
                 HexadecimalColor(0x74dfff),
                 HexadecimalColor(0x9aebff),
                 HexadecimalColor(0xcdf5fe),
-                HexadecimalColor(0xfff8abd),
+                HexadecimalColor(0xff8abd),
             ],
             Self::Aroace => vec![
                 HexadecimalColor(0xe28c00),


### PR DESCRIPTION
Fixes/adds the following:

- The last color in the transmasculine flag had one too many f's (leading to yellow and not pink). Still surprised how it didn't throw an error.
- Adds VS Code folders to gitignore
- Bumps version to 0.2.1 (and by extension, slightly extends the description in cargo.toml)
- Adds myself to authors list